### PR TITLE
Hex vs bytes

### DIFF
--- a/src/chrome/js/peerio/ui/UI.userMenu.js
+++ b/src/chrome/js/peerio/ui/UI.userMenu.js
@@ -7,16 +7,16 @@ Peerio.UI.controller('userMenu', function($scope) {
 			Peerio.user.miniLockID
 		)
 		$scope.userMenu.avatarIcon1 = 'data:image/png;base64,' + new Identicon(
-			avatar[0].substring(0, 16), 30
+			avatar[0].substring(0, 32), 30
 		).toString()
 		$scope.userMenu.avatarIcon2 = 'data:image/png;base64,' + new Identicon(
-			avatar[0].substring(16, 32), 30
+			avatar[0].substring(32, 64), 30
 		).toString()
 		$scope.userMenu.avatarIcon3 = 'data:image/png;base64,' + new Identicon(
-			avatar[1].substring(0, 16), 30
+			avatar[1].substring(0, 32), 30
 		).toString()
 		$scope.userMenu.avatarIcon4 = 'data:image/png;base64,' + new Identicon(
-			avatar[1].substring(16, 32), 30
+			avatar[1].substring(32, 64), 30
 		).toString()
 		if (Peerio.user.firstName.length >= 11) {
 			$scope.userMenu.firstName = Peerio.user.firstName.substring(0, 8) + '..'


### PR DESCRIPTION
This caused a loss of 2 bits per identicon. Now generates 14,942,208 (456 * 2 ^ 15) different images per identicon. So this is like verifying a ~95.33 bit hash (although most probably can't distinguish some colors for each other).